### PR TITLE
Handle MetaBox not having version or flag fields

### DIFF
--- a/src/main/java/net/sourceforge/jaad/mp4/boxes/impl/MetaBox.java
+++ b/src/main/java/net/sourceforge/jaad/mp4/boxes/impl/MetaBox.java
@@ -2,6 +2,7 @@ package net.sourceforge.jaad.mp4.boxes.impl;
 
 import java.io.IOException;
 import net.sourceforge.jaad.mp4.MP4InputStream;
+import net.sourceforge.jaad.mp4.boxes.BoxTypes;
 import net.sourceforge.jaad.mp4.boxes.FullBox;
 
 //needs to be defined, because readChildren() is not called by factory
@@ -15,7 +16,13 @@ public class MetaBox extends FullBox {
 
 	@Override
 	public void decode(MP4InputStream in) throws IOException {
-		super.decode(in);
+		// some encoders (such as Android's MexiaMuxer) do not include
+		// the version and flags fields in the meta box, instead going
+		// directly to the hdlr box
+		long possibleType = in.peekBytes(8) & 0xFFFFFFFFL;
+		if(possibleType != BoxTypes.HANDLER_BOX){
+			super.decode(in);
+		}
 		readChildren(in);
 	}
 }


### PR DESCRIPTION
Some encoders (including Android's MediaMuxer) don't include the version or flag fields on MetaBox.

Without this fix, when using JAAD against some MP4 files, this exception will occur:

```
java.io.IOException: error while decoding box '
    at net.sourceforge.jaad.mp4.boxes.BoxFactory.parseBox(BoxFactory.java:347)
    at net.sourceforge.jaad.mp4.boxes.BoxImpl.readChildren(BoxImpl.java:110)
    at net.sourceforge.jaad.mp4.boxes.impl.MetaBox.decode(MetaBox.java:19)
    at net.sourceforge.jaad.mp4.boxes.BoxFactory.parseBox(BoxFactory.java:353)
    at net.sourceforge.jaad.mp4.boxes.BoxImpl.readChildren(BoxImpl.java:110)
    at net.sourceforge.jaad.mp4.boxes.BoxFactory.parseBox(BoxFactory.java:357)
    at net.sourceforge.jaad.mp4.MP4Container.readContent(MP4Container.java:90)
    at net.sourceforge.jaad.mp4.MP4Container.<init>(MP4Container.java:74)
    at net.sourceforge.jaad.spi.javasound.MP4AudioInputStream.<init>(MP4AudioInputStream.java:25)
    at net.sourceforge.jaad.spi.javasound.AACAudioFileReader.getAudioInputStream(AACAudioFileReader.java:122)
    at net.sourceforge.jaad.spi.javasound.AACAudioFileReader.getAudioInputStream(AACAudioFileReader.java:154)
    at javax.sound.sampled.AudioSystem.getAudioInputStream(AudioSystem.java:1181)
```
