### PR TITLE
Fix rejecting valid streams

### DIFF
--- a/src/main/java/net/sourceforge/jaad/adts/ADTSDemultiplexer.java
+++ b/src/main/java/net/sourceforge/jaad/adts/ADTSDemultiplexer.java
@@ -43,11 +43,7 @@ public class ADTSDemultiplexer {
 			left--;
 			if(i==0xFF) {
 				i = in.read();
-				if(((i>>4)&0xF)==0xF) {
-					if ((i&8)==0)
-						found = true;
-					else break; // mp3
-				}
+				if((i&0xF6)==0xF0) found = true;
 				in.unread(i);
 			}
 		}


### PR DESCRIPTION
The 4th bit does not mean that the stream is mp3

Instead, check that layer (bits 2 and 3) are all zero
AAC uses layer 0 and MPEG Audio uses layers 1/2/3

The break was also removed since this can cause it to prematurely break on false negatives.