### PR TITLE
patch for non aac m4a, and working with other spi

### DIFF
--- a/src/main/java/net/sourceforge/jaad/spi/javasound/AACAudioFileReader.java
+++ b/src/main/java/net/sourceforge/jaad/spi/javasound/AACAudioFileReader.java
@@ -126,8 +126,12 @@ public class AACAudioFileReader extends AudioFileReader {
 			throw e;
 		}
 		catch(IOException e) {
-			in.reset();
-			throw e;
+		    if (e.getMessage().equals(MP4AudioInputStream.ERROR_MESSAGE_AAC_TRACK_NOT_FOUND)) {
+		        throw new UnsupportedAudioFileException(MP4AudioInputStream.ERROR_MESSAGE_AAC_TRACK_NOT_FOUND);
+		    } else {
+		        in.reset();
+		        throw e;
+		    }
 		}
 	}
 

--- a/src/main/java/net/sourceforge/jaad/spi/javasound/MP4AudioInputStream.java
+++ b/src/main/java/net/sourceforge/jaad/spi/javasound/MP4AudioInputStream.java
@@ -20,12 +20,14 @@ class MP4AudioInputStream extends AsynchronousAudioInputStream {
 	private AudioFormat audioFormat;
 	private byte[] saved;
 
+	static final String ERROR_MESSAGE_AAC_TRACK_NOT_FOUND = "movie does not contain any AAC track";
+
 	MP4AudioInputStream(InputStream in, AudioFormat format, long length) throws IOException {
 		super(in, format, length);
 		final MP4Container cont = new MP4Container(in);
 		final Movie movie = cont.getMovie();
 		final List<Track> tracks = movie.getTracks(AudioTrack.AudioCodec.AAC);
-		if(tracks.isEmpty()) throw new IOException("movie does not contain any AAC track");
+		if(tracks.isEmpty()) throw new IOException(ERROR_MESSAGE_AAC_TRACK_NOT_FOUND);
 		track = (AudioTrack) tracks.get(0);
 
 		decoder = new Decoder(track.getDecoderSpecificInfo());


### PR DESCRIPTION
currently JAADec doesn't support mp4 files which contain non aac codec sound.
if we use other spi which deal mp4 files and different codec, this spi will be crashed by `IOException`.

so that i made this patch that makes working well with other mp4 spi