### PR TITLE
issue#11

### DIFF
--- a/src/main/java/net/sourceforge/jaad/aac/DecoderConfig.java
+++ b/src/main/java/net/sourceforge/jaad/aac/DecoderConfig.java
@@ -188,7 +188,7 @@ public class DecoderConfig implements Constants {
 
 					if(config.channelConfiguration==ChannelConfiguration.CHANNEL_CONFIG_NONE) {
 						//TODO: is this working correct? -> ISO 14496-3 part 1: 1.A.4.3
-						in.skipBits(3); //PCE
+						//in.skipBits(3); //PCE
 						PCE pce = new PCE();
 						pce.decode(in);
 						config.profile = pce.getProfile();

--- a/src/main/java/net/sourceforge/jaad/aac/syntax/DSE.java
+++ b/src/main/java/net/sourceforge/jaad/aac/syntax/DSE.java
@@ -11,6 +11,8 @@ class DSE extends Element {
 	}
 
 	void decode(BitStream in) throws AACException {
+		readElementInstanceTag(in);
+
 		final boolean byteAlign = in.readBool();
 		int count = in.readBits(8);
 		if(count==255) count += in.readBits(8);


### PR DESCRIPTION
While playing mp4 samples like [al05_48](ftp://mpaudconf:adif2mp4@ftp.iis.fhg.de/mpeg4audio-conformance/compressedMp4/al05_48.mp4) I noticed a missing element instance tag to read.
Also those 3 bit padding for an inbound PCE seems to be wrong (at least for the given sample sample).