### PR TITLE
patch for w/ mp3 spi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.sourceforge.jaadec</groupId>
   <artifactId>jaad</artifactId>
-  <version>0.8.5</version>
+  <version>0.8.7</version>
   <description>JAAD is an AAC decoder and MP4 demultiplexer library written completely in Java. It uses no native libraries, is platform-independent and portable. It can read MP4 container from almost every input-stream (files, network sockets etc.) and decode AAC-LC (Low Complexity) and HE-AAC (High Efficiency/AAC+).</description>
   <url>https://github.com/DV8FromTheWorld/JAADec</url>
   <licenses>

--- a/src/main/java/net/sourceforge/jaad/spi/javasound/AACAudioFileReader.java
+++ b/src/main/java/net/sourceforge/jaad/spi/javasound/AACAudioFileReader.java
@@ -128,6 +128,8 @@ public class AACAudioFileReader extends AudioFileReader {
 		catch(IOException e) {
 		    if (e.getMessage().equals(MP4AudioInputStream.ERROR_MESSAGE_AAC_TRACK_NOT_FOUND)) {
 		        throw new UnsupportedAudioFileException(MP4AudioInputStream.ERROR_MESSAGE_AAC_TRACK_NOT_FOUND);
+		    } else if (net.sourceforge.jaad.mp4.MP4Exception.class.isInstance(e)) {
+                throw new UnsupportedAudioFileException(e.getMessage());
 		    } else {
 		        in.reset();
 		        throw e;


### PR DESCRIPTION
hi again,

i found another issue similar to #6 with mp3spi.

playing some mp3 causes crash.

* with jaadec

```
WAVE
AU
AIFF
AIFF-C
Exception in thread "main" java.io.IOException: Resetting to invalid mark
	at java.io.BufferedInputStream.reset(BufferedInputStream.java:448)
	at net.sourceforge.jaad.spi.javasound.AACAudioFileReader.getAudioInputStream(AACAudioFileReader.java:132)
	at net.sourceforge.jaad.spi.javasound.AACAudioFileReader.getAudioInputStream(AACAudioFileReader.java:142)
	at javax.sound.sampled.AudioSystem.getAudioInputStream(AudioSystem.java:1147)
	at Test3.main(Test3.java:47)
```

* w/o jaadec

```
WAVE
AU
AIFF
AIFF-C
MPEG1L3 44100.0 Hz, unknown bits per sample, stereo, unknown frame size, 38.28125 frames/second, 
PCM_SIGNED 44100.0 Hz, 16 bit, stereo, 4 bytes/frame, little-endian
play
```

i think all exceptions (like not found audio track, codec is wrong ... etc.) should be wrapped by `UnsupportedAudioFileException` except pure `IOException`.

---
test case is the same as #6 
[mp3spi](https://mvnrepository.com/artifact/javazoom/mp3spi/1.9.4)

thanks,